### PR TITLE
remove reference to study metadata schema

### DIFF
--- a/ghga_message_schemas/json_schemas/new_study_created.json
+++ b/ghga_message_schemas/json_schemas/new_study_created.json
@@ -49,7 +49,19 @@
       "type": "array"
     },
     "study": {
-      "$ref": "https://raw.githubusercontent.com/ghga-de/ghga-metadata-schema/main/artifacts/jsonschema/ghga.schema.json#/definitions/Study"
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "description": "The internal unique identifier for an entity.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "accession",
+        "format"
+      ],
+      "type": "object"
     },
     "timestamp": {
       "description": "The time when the message was published.",

--- a/ghga_message_schemas/json_schemas/new_study_created.json
+++ b/ghga_message_schemas/json_schemas/new_study_created.json
@@ -57,9 +57,7 @@
         }
       },
       "required": [
-        "id",
-        "accession",
-        "format"
+        "id"
       ],
       "type": "object"
     },


### PR DESCRIPTION
Title for squash and merge:
```
remove reference to study metadata schema
```

Description:
```
Replace reference to external metadata schema for the Study type
with a simplified object with the only required property "id".
```