### PR TITLE
remove reference to study metadata schema

### DIFF
--- a/ghga_message_schemas/__init__.py
+++ b/ghga_message_schemas/__init__.py
@@ -15,4 +15,4 @@
 
 """A package that collects schemas used for messaging between GHGA service."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.1"

--- a/ghga_message_schemas/json_schemas/new_study_created.json
+++ b/ghga_message_schemas/json_schemas/new_study_created.json
@@ -49,7 +49,17 @@
       "type": "array"
     },
     "study": {
-      "$ref": "https://raw.githubusercontent.com/ghga-de/ghga-metadata-schema/main/artifacts/jsonschema/ghga.schema.json#/definitions/Study"
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "description": "The internal unique identifier for an entity.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
     },
     "timestamp": {
       "description": "The time when the message was published.",


### PR DESCRIPTION
Replace reference to external metadata schema for the Study type
with a simplified object with the only required property "id".